### PR TITLE
replace toggle effect with animation and max-height

### DIFF
--- a/index.html
+++ b/index.html
@@ -109,7 +109,7 @@
       </ul>
     </div>
   </main>
-  <script src="./script.js" integrity="sha512-"></script>
+  <script src="./script.js"></script>
 </body>
 
 </html>

--- a/script.js
+++ b/script.js
@@ -1,5 +1,5 @@
 const questions = document.querySelectorAll('.faq-accordion__question-wrapper');
-const answer = document.querySelectorAll('.faq-accordion__answer');
+const answers = document.querySelectorAll('.faq-accordion__answer');
 
 questions.forEach((question, index) => {
   question.addEventListener('click', () => {
@@ -9,11 +9,15 @@ questions.forEach((question, index) => {
 });
 
 function toggleAnswer(index) {
-  // if the answer is hidden, remove the hidden class
-  if (answer[index].classList.contains('hidden')) {
-    answer[index].classList.remove('hidden');
+  const ans = answers[index];
+  console.log(index, ans);
+  if (ans.classList.contains('active')) {
+    ans.classList.remove('active');
+    ans.style.maxHeight = null;
   } else {
-    answer[index].classList.add('hidden');
+    ans.classList.remove('hidden');
+    ans.classList.add('active');
+    ans.style.maxHeight = ans.scrollHeight + 'px';
   }
 }
 

--- a/styles/main.css
+++ b/styles/main.css
@@ -91,14 +91,23 @@ body {
 }
 
 .faq-accordion__answer {
-  color: var(--Pale-Purple, #8b6990);
+  max-height: 0;
+  overflow: hidden;
+  opacity: 0;
+  transition: max-height 0.5s ease, opacity 0.5s ease;
 
   /* Body */
+  color: var(--Pale-Purple, #8b6990);
   font-family: "Work Sans";
   font-size: 16px;
   font-style: normal;
   font-weight: 400;
   line-height: 150%;
+}
+
+.faq-accordion__answer.active {
+  max-height: 500px;
+  opacity: 1;
 }
 
 .faq-accordion__separator {


### PR DESCRIPTION
I'm use the max-height to replace the toggle,

``` css
.faq-accordion__answer {
  max-height: 0;
  overflow: hidden;
  opacity: 0;
  transition: max-height 0.5s ease, opacity 0.5s ease;
}
```

``` javascript
function toggleAnswer(index) {
  const ans = answers[index];
  console.log(index, ans);
  if (ans.classList.contains('active')) {
    ans.classList.remove('active');
    ans.style.maxHeight = null;
  } else {
    ans.classList.remove('hidden');
    ans.classList.add('active');
    ans.style.maxHeight = ans.scrollHeight + 'px';
  }
```

use `style.maxHeight = scrollHeight + 'px'` can make the expansion and collapse more smoothly.